### PR TITLE
[BUGFIX] Replace non-existent TCA-type "display" with "none"

### DIFF
--- a/Configuration/TCA/Forum/Forum.php
+++ b/Configuration/TCA/Forum/Forum.php
@@ -120,14 +120,14 @@ $TCA['tx_mmforum_domain_model_forum_forum'] = array(
 			'exclude' => 0,
 			'label'   => 'LLL:EXT:mm_forum/Resources/Private/Language/locallang_db.xml:tx_mmforum_domain_model_forum_forum.topic_count',
 			'config'  => array(
-				'type' => 'display'
+				'type' => 'none'
 			)
 		),
 		'post_count' => array(
 			'exclude' => 0,
 			'label'   => 'LLL:EXT:mm_forum/Resources/Private/Language/locallang_db.xml:tx_mmforum_domain_model_forum_forum.post_count',
 			'config'  => array(
-				'type' => 'display'
+				'type' => 'none'
 			)
 		),
 		'acls' => array(

--- a/Configuration/TCA/Forum/Topic.php
+++ b/Configuration/TCA/Forum/Topic.php
@@ -108,7 +108,7 @@ $TCA['tx_mmforum_domain_model_forum_topic'] = array(
 			'exclude' => 1,
 			'label'   => 'LLL:EXT:mm_forum/Resources/Private/Language/locallang_db.xml:tx_mmforum_domain_model_forum_topic.post_count',
 			'config'  => array(
-				'type' => 'display'
+				'type' => 'none'
 			)
 		),
 		'author' => array(
@@ -135,14 +135,14 @@ $TCA['tx_mmforum_domain_model_forum_topic'] = array(
 			'exclude' => 0,
 			'label'   => 'LLL:EXT:mm_forum/Resources/Private/Language/locallang_db.xml:tx_mmforum_domain_model_forum_topic.last_post_crdate',
 			'config'  => array(
-				'type' => 'display',
+				'type' => 'none'
 			)
 		),
 		'is_solved' => array(
 			'exclude' => 0,
 			'label'   => 'LLL:EXT:mm_forum/Resources/Private/Language/locallang_db.xml:tx_mmforum_domain_model_forum_topic.is_solved',
 			'config'  => array(
-				'type' => 'display',
+				'type' => 'none'
 			)
 		),
 		'solution' => array(

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -314,7 +314,7 @@ $tempColumns = array(
 		'exclude' => 0,
 		'label' => 'LLL:EXT:mm_forum/Resources/Private/Language/locallang_db.xml:fe_users.contact',
 		'config' => array(
-			'type' => 'display'
+			'type' => 'none'
 		)
 	),
 	"tx_mmforum_facebook" => Array(


### PR DESCRIPTION
Those fields are just meant to be displayed. That's what type
'none' does. There is no type 'display'.
