### PR TITLE
[BUGFIX] Allow panels to return no content

### DIFF
--- a/Classes/TextParser/Panel/SmiliePanel.php
+++ b/Classes/TextParser/Panel/SmiliePanel.php
@@ -83,8 +83,11 @@ class Tx_MmForum_TextParser_Panel_SmiliePanel extends Tx_MmForum_TextParser_Pane
 	 * @return array
 	 */
 	public function getItems() {
-		$result = array();
+		if (count($this->smilies) === 0) {
+			return FALSE;
+		}
 
+		$result = array();
 		foreach ($this->smilies as $smilie) {
 			$result[] = $smilie->exportForMarkItUp();
 		}

--- a/Classes/ViewHelpers/Form/BbCodeEditorViewHelper.php
+++ b/Classes/ViewHelpers/Form/BbCodeEditorViewHelper.php
@@ -207,8 +207,11 @@ class Tx_MmForum_ViewHelpers_Form_BbCodeEditorViewHelper extends \TYPO3\CMS\Flui
 	protected function getPanelSettings() {
 		$settings = array();
 		foreach ($this->panels as $panel) {
-			$settings   = array_merge($settings, $panel->getItems());
-			$settings[] = array('separator' => '---------------');
+			$items = $panel->getItems();
+			if (!empty($items)) {
+				$settings   = array_merge($settings, $items);
+				$settings[] = array('separator' => '---------------');
+			}
 		}
 
 		$settings[] = array('name'      => 'Preview',


### PR DESCRIPTION
If there are no smileys, don't throw an error.
Instead just don't add that panel.

Allow panels to return nothing, and in that case
don't add anything (also no separator).
