### PR TITLE
[BUGFIX] Add display for first post of a topic

### DIFF
--- a/Resources/Private/Templates/Topic/Show.html
+++ b/Resources/Private/Templates/Topic/Show.html
@@ -10,6 +10,8 @@
 
 	<mmf:forum.rootline rootline="{topic.rootline}" />
 
+	<f:render partial="Post/Single" arguments="{post: topic.firstpost}" />
+
 	<f:widget.paginate objects="{posts}" as="paginatedPosts" configuration="{settings.topicController.show.pagebrowser}">
 		<f:for each="{paginatedPosts}" as="post">
 			<f:render partial="Post/Single" arguments="{post: post}" />


### PR DESCRIPTION
Currently the list of posts starts from the second posting and
is paginated. The first post is separately (and always) shown
above the other paginated posts.
