### PR TITLE
[FEATURE] Allow additional configuration of markup-editor through TS

### DIFF
--- a/Classes/ViewHelpers/Form/BbCodeEditorViewHelper.php
+++ b/Classes/ViewHelpers/Form/BbCodeEditorViewHelper.php
@@ -218,9 +218,16 @@ class Tx_MmForum_ViewHelpers_Form_BbCodeEditorViewHelper extends \TYPO3\CMS\Flui
 		                    'className' => 'preview',
 		                    'call'      => 'preview');
 
-		return array('previewParserPath' => 'index.php?eID=mm_forum&tx_mmforum_ajax[controller]=Post&tx_mmforum_ajax[action]=preview&id=' . $GLOBALS['TSFE']->id,
-		             'previewParserVar'  => 'tx_mmforum_ajax[text]',
-		             'markupSet'         => $settings);
+		$editorSettings = array(
+			'previewParserPath' => 'index.php?eID=mm_forum&tx_mmforum_ajax[controller]=Post&tx_mmforum_ajax[action]=preview&id=' . $GLOBALS['TSFE']->id,
+			'previewParserVar'  => 'tx_mmforum_ajax[text]',
+			'markupSet'         => $settings);
+
+		if (isset($this->configuration['editorSettings.']) && is_array($this->configuration['editorSettings.'])) {
+			$editorSettings = array_merge($editorSettings, $this->configuration['editorSettings.']);
+		}
+
+		return $editorSettings;
 	}
 
 


### PR DESCRIPTION
Add a TypoScript-setting for editorSettings. This allows to
provide additional (or override exiting) settings of the
markup-editor.
