### PR TITLE
[TASK] Remove offset for fetching posts of a topic

### DIFF
--- a/Classes/Domain/Repository/Forum/PostRepository.php
+++ b/Classes/Domain/Repository/Forum/PostRepository.php
@@ -113,7 +113,6 @@ class Tx_MmForum_Domain_Repository_Forum_PostRepository extends Tx_MmForum_Domai
 		$query->getQuerySettings()->setRespectSysLanguage(FALSE) ;
 		return $query->matching($query->equals('topic', $topic))
 			->setOrderings(array('crdate' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING))
-			->setOffset(1)
 			->setLimit(1000000)
 			->execute();
 	}

--- a/Resources/Private/Templates/Topic/Show.html
+++ b/Resources/Private/Templates/Topic/Show.html
@@ -10,8 +10,6 @@
 
 	<mmf:forum.rootline rootline="{topic.rootline}" />
 
-	<f:render partial="Post/Single" arguments="{post: topic.firstpost}" />
-
 	<f:widget.paginate objects="{posts}" as="paginatedPosts" configuration="{settings.topicController.show.pagebrowser}">
 		<f:for each="{paginatedPosts}" as="post">
 			<f:render partial="Post/Single" arguments="{post: post}" />


### PR DESCRIPTION
The variable "posts" should contain all postings of a topic.
Currently it starts from the second posting (offset: 1) because
typo3.net wanted to have a special handing for the first posting.

If you need a to remove the first posting from the pagination
because you handle it separately, consider using something like
the slice-viewhelper from EXT:vhs.
https://github.com/FluidTYPO3/vhs/tree/development/Classes/ViewHelpers/Iterator
