### PR TITLE
[TASK] UserRepository: Get rid of findByUsername()

### DIFF
--- a/Classes/Controller/UserController.php
+++ b/Classes/Controller/UserController.php
@@ -360,7 +360,7 @@ class Tx_MmForum_Controller_UserController extends Tx_MmForum_Controller_Abstrac
 	 */
 	public function createMessageAction($recipient, $text) {
 		$user = $this->getCurrentUser();
-		$recipient = $this->frontendUserRepository->findByUsername($recipient);
+		$recipient = $this->frontendUserRepository->findOneByUsername($recipient);
 		if ($user->isAnonymous()) {
 			throw new Tx_MmForum_Domain_Exception_Authentication_NotLoggedInException("You need to be logged in.", 1288084981);
 		}

--- a/Classes/Domain/Repository/User/FrontendUserRepository.php
+++ b/Classes/Domain/Repository/User/FrontendUserRepository.php
@@ -145,22 +145,6 @@ class Tx_MmForum_Domain_Repository_User_FrontendUserRepository
 
 
 	/**
-	 * Finds a user by his/her username. Please note that in difference to the usual
-	 * findBy* methods, this method does NOT return an array of values, but instead
-	 * a single user object, or NULL. This behaviour is due to the fact that
-	 * usernames are supposed to be unique; consequently, in any case this method
-	 * should not return more than one user.
-	 *
-	 * Technically, this method is just an alias for "findOneByUsername".
-	 *
-	 * @param  string $username                          The username.
-	 * @return Tx_MmForum_Domain_Model_User_FrontendUser The frontend user with the specified username.
-	 */
-	public function findByUsername($username) {
-		return $this->findOneByUsername($username);
-	}
-
-	/**
 	 * Find all user with a part of $username in his name
 	 * @param $part Part of the users nickname
 	 * @param $filter Order by which field?

--- a/Classes/Domain/Validator/User/PrivateMessageRecipientValidator.php
+++ b/Classes/Domain/Validator/User/PrivateMessageRecipientValidator.php
@@ -66,7 +66,7 @@ class Tx_MmForum_Domain_Validator_User_PrivateMessageRecipientValidator extends 
 	protected function isValid($value) {
 		$result = TRUE;
 
-		if (!$this->userRepository->findByUsername($value)) {
+		if (!$this->userRepository->findOneByUsername($value)) {
 				$this->addError('PM reciepient user not found!', 1372429326);
 				$result = FALSE;
 		}


### PR DESCRIPTION
Use findOneByUsername() from Extbase instead, which has the
same behaviour used here so far. Method findByUsername() was
there to only return one record - but that breaks with
Extbase-naming and is inconsistent.

Fixes: #41
