### PR TITLE
[BUGFIX] Use pageUid for link from post-summary to forum

### DIFF
--- a/Resources/Private/Partials/Post/Summary.html
+++ b/Resources/Private/Partials/Post/Summary.html
@@ -1,7 +1,7 @@
 <f:if condition="{post}">
 	<f:then>
 		<div>
-			<f:link.action controller="Post" action="show" arguments="{post: post}">{post.topic.subject}</f:link.action>
+			<f:link.action controller="Post" action="show" arguments="{post: post}" pageUid="{settings.pids.Forum}">{post.topic.subject}</f:link.action>
 		</div>
 		<div>
 			<f:format.date format="d.m.Y H:i">{post.timestamp}</f:format.date> <f:translate key="Generic_By" />


### PR DESCRIPTION
The post-summary-template is also used inside the usershow-view,
which displays a user-profile. To correctly link to the forum,
the pageUid needs to be specified.
