### PR TITLE
[BUGFIX] Use forum-object when adding/removing a topic

### DIFF
--- a/Classes/Domain/Factory/Forum/TopicFactory.php
+++ b/Classes/Domain/Factory/Forum/TopicFactory.php
@@ -148,7 +148,7 @@ class Tx_MmForum_Domain_Factory_Forum_TopicFactory extends Tx_MmForum_Domain_Fac
 		$topic = $this->getClassInstance();
 		$user = $this->getCurrentUser();
 
-		$topic->setForum($forum);
+		$forum->addTopic($topic);
 		$topic->setSubject($subject);
 		$topic->setAuthor($user);
 		$topic->setQuestion($question);
@@ -178,9 +178,6 @@ class Tx_MmForum_Domain_Factory_Forum_TopicFactory extends Tx_MmForum_Domain_Fac
 		}
 		$this->topicRepository->add($topic);
 
-		$topic->getForum()->setLastTopic($topic);
-		$this->forumRepository->update($topic->getForum());
-
 		return $topic;
 	}
 
@@ -198,21 +195,10 @@ class Tx_MmForum_Domain_Factory_Forum_TopicFactory extends Tx_MmForum_Domain_Fac
 		}
 
 		$forum = $topic->getForum();
+		$forum->removeTopic($topic);
 		$this->topicRepository->remove($topic);
 
 		$this->persistenceManager->persistAll();
-
-		$forum->_resetLastPost();
-
-		$lastTopic = $this->topicRepository->findLastByForum($forum);
-		if($lastTopic !== NULL) {
-			$lastPost = $lastTopic->getLastPost();
-		} else {
-			$lastPost = NULL;
-		}
-		$forum->setLastPost($lastPost);
-		$forum->setLastTopic($lastTopic);
-		$this->forumRepository->update($forum);
 
 		$user = $this->getCurrentUser();
 

--- a/Classes/Domain/Model/Forum/Forum.php
+++ b/Classes/Domain/Model/Forum/Forum.php
@@ -737,9 +737,12 @@ class Tx_MmForum_Domain_Model_Forum_Forum extends \TYPO3\CMS\Extbase\DomainObjec
 		if ($this->lastTopic === NULL || $this->lastTopic->getTimestamp() <= $topic->getTimestamp()) {
 			$this->setLastTopic($topic);
 		}
-		if ($this->lastPost === NULL || $this->lastPost->getTimestamp() <= $topic->getLastPost()->getTimestamp()) {
+		$topicLastPost = $topic->getLastPost();
+		if (($topicLastPost !== NULL) && ($this->lastPost === NULL || $this->lastPost->getTimestamp() <= $topicLastPost->getTimestamp())) {
 			$this->setLastPost($topic->getLastPost());
 		}
+		$this->_increaseTopicCount(+1);
+		// topic will increase postCount itself when adding the initial post to it
 
 		$topic->setForum($this);
 		$this->topics->attach($topic);
@@ -756,6 +759,8 @@ class Tx_MmForum_Domain_Model_Forum_Forum extends \TYPO3\CMS\Extbase\DomainObjec
 	public function removeTopic(Tx_MmForum_Domain_Model_Forum_Topic $topic) {
 		$this->topics->detach($topic);
 		$this->_resetCounters();
+		$this->_resetLastPost();
+		$this->_resetLastTopic();
 	}
 
 


### PR DESCRIPTION
When adding a new topic the topic-counter in the forum was not
increased. Let the existing functions addTopic/removeTopic in the
forum-object take care of needed actions.

In topicFactory add the topic to a forum first, so that addPost()
can afterwards update the forum properly (set lastPost etc.).

When adding a new topic forum needs to take into account that a
lastPost might not yet exist (empty topic).
