### PR TITLE
[BUGFIX] RootlineViewHelper: Remove additional space

### DIFF
--- a/Classes/ViewHelpers/Forum/RootlineViewHelper.php
+++ b/Classes/ViewHelpers/Forum/RootlineViewHelper.php
@@ -123,7 +123,7 @@ class Tx_MmForum_ViewHelpers_Forum_RootlineViewHelper extends \TYPO3\CMS\Fluid\C
 		$uri        = $uriBuilder->reset()->setTargetPageUid((int)$this->settings['pids']['Forum'])
 			->uriFor('show', $arguments, $controller);
 
-		return '<li><a href="' . $uri . '" title="'.$fullTitle.'"><i class="' . $icon . '"></i> ' . $title . '</a></li>';
+		return '<li><a href="' . $uri . '" title="'.$fullTitle.'"><i class="' . $icon . '"></i>' . $title . '</a></li>';
 	}
 
 


### PR DESCRIPTION
For the navigation-node there is one space too much,
compared with the main-forum-node. Unify this.
Depending on CSS/font otherwise there are problems in the layout.
