### PR TITLE
Fix php method arguments on null

### DIFF
--- a/Classes/Domain/Model/Forum/Post.php
+++ b/Classes/Domain/Model/Forum/Post.php
@@ -275,7 +275,7 @@ class Post extends AbstractEntity implements AccessibleInterface, NotifiableInte
 	 * @param string $operation
 	 * @return boolean TRUE, if the user is allowed to edit this post, otherwise FALSE.
 	 */
-	public function checkEditOrDeletePostAccess(FrontendUser $user, $operation) {
+	public function checkEditOrDeletePostAccess(FrontendUser $user = NULL, $operation) {
 		if ($user === NULL || $user->isAnonymous()) {
 			return FALSE;
 		} else {


### PR DESCRIPTION
We are using different user and usergroups for different parts of a TYPO3 installation, with different access rights. This fix avoids Fatal error on viewing forum posts for none forum members.

See also https://github.com/mittwald/typo3_forum/issues/100