### PR TITLE
[!!!][BUGFIX] Show link to topic in topic subscription mail

### DIFF
--- a/Classes/Domain/Factory/Forum/TopicFactory.php
+++ b/Classes/Domain/Factory/Forum/TopicFactory.php
@@ -120,6 +120,9 @@ class TopicFactory extends AbstractFactory {
 		}
 		$this->topicRepository->add($topic);
 
+		// Persist in order to have an already persisted $topic with uid in topicCreated
+		$this->persistenceManager->persistAll();
+
 		return $topic;
 	}
 

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -932,7 +932,7 @@ Dein ###FORUM_TEAM###-Team</label>
 			<label index="Mail_Subscribe_NewTopic_Subject">Neues Thema in einem von Dir abonnierten Forum!</label>
 			<label index="Mail_Subscribe_NewTopic_Body">Hallo ###RECIPIENT###,
 
-###POST_AUTHOR### hat das Thema "###TOPIC_NAME###" in dem von dir abonnierten Forum ###FORUM_LINK### erstellt.
+###POST_AUTHOR### hat das Thema ###TOPIC_LINK### in dem von dir abonnierten Forum ###FORUM_LINK### erstellt.
 
 Falls Du keine Benachrichtigungen zu diesem Forum mehr erhalten möchtest, kannst Du diese im Forum oder mit folgendem Link abbestellen: ###UNSUBSCRIBE_LINK###
 


### PR DESCRIPTION
This change makes post in postCreated and topic in topicCreated
available as persisted objects. When sending a notification
email for a newly created topic it now contains a link to the
topic. This was not possible before as the topic had not been
persisted yet when sending the mail.

This also circumvents issues with sending the mail leading to
the post or topic not being created.

This changes the behaviour for other subscribers as the post
and topic have already been persisted in the slots "topicCreated"
and "postCreated".