### PR TITLE
[BUGFIX] Correct translations for notifications

### DIFF
--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -317,9 +317,9 @@ If you don't want to get more notifications about this topic, you can unsubscrib
 Yours sincerely,
 Your ###FORUM_TEAM###-Team</label>
 			<label index="Mail_Subscribe_NewPost_Subject">New topic in one of your subscribed forums!</label>
-			<label index="Mail_Subscribe_NewPost_Body">Hello ###RECIPIENT###,
+			<label index="Mail_Subscribe_NewTopic_Body">Hello ###RECIPIENT###,
 
-###POST_AUTHOR### created a new topic ###TOPIC_LINK### in one of your subscribed forums ###FORUM_NAME###.
+###POST_AUTHOR### created a new topic "###TOPIC_NAME###" in one your subscribed forum ###FORUM_LINK###.
 
 If you don't want to get more notifications about this forum, you can unsubscribe from this forum in the forum or using this link: ###UNSUBSCRIBE_LINK###
 


### PR DESCRIPTION
This patch fixes the english translations for `Mail_Subscribe_NewPost_Body` and `Mail_Subscribe_NewTopic_Body` which were mixed up and did not contain the fixes of https://github.com/AgenturPottkinder/typo3_forum/commit/8e2d22e5ff716d5c3a56dd7dec04875c8983a85d#diff-7e8e3103f38f06fd377c7adae66f6c85

Fixes: https://github.com/AgenturPottkinder/typo3_forum/issues/352