### PR TITLE
Check if image exists to avoid ViewHelper Exception

### DIFF
--- a/Classes/ViewHelpers/User/AvatarViewHelper.php
+++ b/Classes/ViewHelpers/User/AvatarViewHelper.php
@@ -60,7 +60,7 @@ class AvatarViewHelper extends ImageViewHelper
             $avatarFilename = $user->getImagePath();
         }
 
-        if ($avatarFilename === null) {
+        if ($avatarFilename === null || !file_exists(avatarFilename)) {
             $avatarFilename = ExtensionManagementUtility::siteRelPath('typo3_forum') . 'Resources/Public/Images/Icons/AvatarEmpty.png';
         }
 


### PR DESCRIPTION
A missing image should not throw an exception so a check if the image exists should be done